### PR TITLE
`async_get_registry` is deprecated, change to `async_get`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@
 
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.2
+    rev: v2.32.1
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
+        args: [ --py39 ]
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         args:
@@ -15,7 +15,7 @@ repos:
           - --quiet
         files: ^((homeassistant|script|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.0.0
+    rev: v2.1.0
     hooks:
       - id: codespell
         args:
@@ -33,7 +33,7 @@ repos:
           - pydocstyle==5.1.1
         files: ^(homeassistant|script|tests)/.+\.py$
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.0
+    rev: 1.7.4
     hooks:
       - id: bandit
         args:
@@ -42,7 +42,7 @@ repos:
           - --configfile=tests/bandit.yaml
         files: ^(homeassistant|script|tests)/.+\.py$
   - repo: https://github.com/PyCQA/isort
-    rev: 5.5.3
+    rev: 5.10.1
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -56,8 +56,8 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-added-large-files
-  - repo: https://github.com/prettier/prettier
-    rev: 2.0.4
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.6.1
     hooks:
       - id: prettier
         stages: [manual]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
+## 1.0.5
+
+- Device and Entity registry - `async_get_registry` is deprecated, change to `async_get`
+- Update pre-commit
+
 ## v1.0.4
- - Whitespace cleanup from consumer, provider and serial number
+
+- Whitespace cleanup from consumer, provider and serial number
 
 ## v1.0.2
 

--- a/custom_components/citymind_water_meter/managers/config_flow_manager.py
+++ b/custom_components/citymind_water_meter/managers/config_flow_manager.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from cryptography.fernet import InvalidToken
 import voluptuous as vol
@@ -103,14 +103,14 @@ class ConfigFlowManager:
 
     def _get_default_fields(
         self, flow, config_data: ConfigData = None
-    ) -> Dict[vol.Marker, Any]:
+    ) -> dict[vol.Marker, Any]:
         if config_data is None:
             config_data = self.config_data
 
         username = config_data.username
         password_clear_text = config_data.password_clear_text
 
-        fields: Dict[vol.Marker, Any] = {
+        fields: dict[vol.Marker, Any] = {
             vol.Optional(CONF_USERNAME, default=username): str,
             vol.Optional(CONF_PASSWORD, default=password_clear_text): str,
         }

--- a/custom_components/citymind_water_meter/managers/device_manager.py
+++ b/custom_components/citymind_water_meter/managers/device_manager.py
@@ -1,7 +1,7 @@
 import logging
 
 from homeassistant.const import ATTR_CONFIGURATION_URL
-from homeassistant.helpers.device_registry import async_get_registry
+from homeassistant.helpers.device_registry import async_get
 
 from ..api.api import CityMindApi
 from ..helpers.const import *
@@ -24,7 +24,7 @@ class DeviceManager:
         return self._ha.config_manager
 
     async def async_remove_entry(self, entry_id):
-        dr = await async_get_registry(self._hass)
+        dr = async_get(self._hass)
         dr.async_clear_config_entry(entry_id)
 
     async def delete_device(self, name):
@@ -35,7 +35,7 @@ class DeviceManager:
         device_identifiers = device.get("identifiers")
         device_connections = device.get("connections", {})
 
-        dr = await async_get_registry(self._hass)
+        dr = async_get(self._hass)
 
         device = dr.async_get_device(device_identifiers, device_connections)
 

--- a/custom_components/citymind_water_meter/managers/entity_manager.py
+++ b/custom_components/citymind_water_meter/managers/entity_manager.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from typing import Dict, List, Optional
+from typing import Optional
 
 from homeassistant.const import ATTR_FRIENDLY_NAME, VOLUME_CUBIC_METERS
 from homeassistant.core import HomeAssistant
@@ -74,7 +74,7 @@ class EntityManager:
 
         return result
 
-    def get_all_entities(self) -> List[EntityData]:
+    def get_all_entities(self) -> list[EntityData]:
         entities = []
         for domain in self.entities:
             for name in self.entities[domain]:
@@ -88,7 +88,7 @@ class EntityManager:
         if domain not in self.entities:
             self.entities[domain] = {}
 
-    def get_entities(self, domain) -> Dict[str, EntityData]:
+    def get_entities(self, domain) -> dict[str, EntityData]:
         self.check_domain(domain)
 
         return self.entities[domain]

--- a/custom_components/citymind_water_meter/managers/home_assistant.py
+++ b/custom_components/citymind_water_meter/managers/home_assistant.py
@@ -13,10 +13,7 @@ from cryptography.fernet import InvalidToken
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.entity_registry import (
-    EntityRegistry,
-    async_get_registry as er_async_get_registry,
-)
+from homeassistant.helpers.entity_registry import EntityRegistry, async_get
 from homeassistant.helpers.event import async_track_time_interval
 
 from ..api.api import CityMindApi
@@ -90,7 +87,7 @@ class CityMindHomeAssistant:
             self._entity_manager = EntityManager(self._hass, self)
             self._device_manager = DeviceManager(self._hass, self)
 
-            self._entity_registry = await er_async_get_registry(self._hass)
+            self._entity_registry = async_get(self._hass)
 
             self._hass.loop.create_task(self._async_init())
         except InvalidToken:

--- a/custom_components/citymind_water_meter/manifest.json
+++ b/custom_components/citymind_water_meter/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "citymind_water_meter",
   "name": "CityMind Water Meter",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "documentation": "https://github.com/maorcc/citymind_water_meter",
   "issue_tracker": "https://github.com/maorcc/citymind_water_meter/issues",
   "dependencies": [],

--- a/custom_components/citymind_water_meter/models/base_entity.py
+++ b/custom_components/citymind_water_meter/models/base_entity.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import sys
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -72,7 +72,7 @@ class CityMindEntity(SensorEntity):
         self.api = self.ha.api
 
     @property
-    def unique_id(self) -> Optional[str]:
+    def unique_id(self) -> str | None:
         """Return the name of the node."""
         return self.entity.unique_id
 
@@ -106,7 +106,7 @@ class CityMindEntity(SensorEntity):
         return self.entity.attributes
 
     @property
-    def unit_of_measurement(self) -> Optional[str]:
+    def unit_of_measurement(self) -> str | None:
         return self.entity.unit
 
     @property


### PR DESCRIPTION
Fix #26 - Device and Entity registry - `async_get_registry` is deprecated, change to `async_get`
Update pre-commit
